### PR TITLE
Refactor operation validity laws

### DIFF
--- a/LeanYjs/Network/StrongCausalOrder.lean
+++ b/LeanYjs/Network/StrongCausalOrder.lean
@@ -81,14 +81,6 @@ class Operation (A : Type) where
   Error : Type
   init : State
   effect : A → State → Except Error State
-  isValidState : A → State → Prop
-  StateInv : State → Prop := fun _ => True
-  stateInv_init : StateInv init
-  stateInv_effect : ∀ (op : A) (s s' : State),
-    StateInv s →
-    isValidState op s →
-    effect op s = Except.ok s' →
-    StateInv s'
 
 def effect_list [Operation A] (ops : List A) (s : Operation.State A) :=
   foldlM (fun s op => Operation.effect op s) s ops
@@ -108,28 +100,42 @@ def effect_list [Operation A] (ops : List A) (s : Operation.State A) :=
     simp [effect_list]
   | cons a ops₀ ih =>
     simp [effect_list]
+
+class OperationValidity (A : Type) [Operation A] where
+  isValidState : A → Operation.State A → Prop
+  StateInv : Operation.State A → Prop := fun _ => True
+  stateInv_init : StateInv (Operation.init (A := A))
+  stateInv_effect : ∀ (op : A) (s s' : Operation.State A),
+    StateInv s →
+    isValidState op s →
+    Operation.effect op s = Except.ok s' →
+    StateInv s'
+
+class OperationReplayValidity
+  (A : Type) [DecidableEq A] {S : Type} [DecidableEq S]
+  [Operation A] [OperationValidity A] [WithId A S]
+  (hb : CausalOrder A) (StateSource : A → Prop) : Prop where
+  isValidState_of_history :
+    ∀ {a : A} {s : Operation.State A} {l : List A},
+      StateSource a →
+      (∀ x < a, x ∈ l) →
+      hb_consistent hb l →
+      hbClosed hb l →
+      effect_list l (Operation.init (A := A)) = Except.ok s →
+      IdNoDup l →
+      OperationValidity.isValidState a s
 end effect
 
 section commutativity
 
 variable {A : Type} [DecidableEq A] {S : Type} [DecidableEq S] {hb : CausalOrder A}
-variable [WithId A S]  [Operation A]
-
-def IsValidStateMonotone (StateSource : A → Prop) : Prop :=
-  ∀ {a : A} {s : Operation.State A} {l : List A},
-    StateSource a →
-    (∀ x < a, x ∈ l) →
-    hb_consistent hb l →
-    hbClosed hb l →
-    effect_list l Operation.init = Except.ok s →
-    IdNoDup l →
-    Operation.isValidState a s
+variable [WithId A S] [Operation A] [OperationValidity A]
 
 def concurrent_commutative (list : List A) : Prop :=
   ∀ a b (s s' : Operation.State A), a ∈ list → b ∈ list → hb_concurrent hb a b →
-    Operation.StateInv s →
-    Operation.isValidState a s →
-    Operation.isValidState b s →
+    OperationValidity.StateInv s →
+    OperationValidity.isValidState a s →
+    OperationValidity.isValidState b s →
     (Operation.effect a s >>= Operation.effect b) = Except.ok s' → (Operation.effect b s >>= Operation.effect a) = Except.ok s'
 
 theorem Except.bind_eq_ok_exist' {α β : Type} {e : Except α β} {f : β → Except α β'} {v : β'} :
@@ -143,19 +149,20 @@ theorem Except.bind_eq_ok_exist' {α β : Type} {e : Except α β} {f : β → E
     refine ⟨u, rfl, ?_⟩
     exact h
 
-theorem effect_list_stateInv (StateSource : A → Prop) (h_valid_mono : IsValidStateMonotone (hb := hb) StateSource) :
+theorem effect_list_stateInv (StateSource : A → Prop)
+  [OperationReplayValidity (A := A) (S := S) (hb := hb) StateSource] :
   ∀ {ops : List A} {s : Operation.State A},
     (∀ op, op ∈ ops → StateSource op) →
     hb_consistent hb ops →
     hbClosed hb ops →
     IdNoDup ops →
     effect_list ops Operation.init = Except.ok s →
-    Operation.StateInv s := by
+    OperationValidity.StateInv s := by
   intro ops s h_source h_consistent h_closed h_no_dup h_effect
   induction ops using List.reverseRecOn generalizing s with
   | nil =>
     cases h_effect
-    exact Operation.stateInv_init (A := A)
+    exact OperationValidity.stateInv_init (A := A)
   | append_singleton ops a ih =>
     have h_consistent_ops : hb_consistent hb ops := by
       apply hb_consistent_sublist (hb := hb) h_consistent
@@ -180,18 +187,20 @@ theorem effect_list_stateInv (StateSource : A → Prop) (h_valid_mono : IsValidS
         simpa using h_last_eq
       subst hs_after
       exact h_last_ok
-    have h_stateInv_prev : Operation.StateInv s_prev :=
+    have h_stateInv_prev : OperationValidity.StateInv s_prev :=
       ih
         (by
           intro op hop
           exact h_source op (by simp [hop]))
         h_consistent_ops h_closed_ops h_no_dup_ops h_prefix
-    have h_valid_a : Operation.isValidState a s_prev := by
-      refine h_valid_mono (a := a) (s := s_prev) (l := ops) ?_ ?_ h_consistent_ops h_closed_ops h_prefix h_no_dup_ops
+    have h_valid_a : OperationValidity.isValidState a s_prev := by
+      refine OperationReplayValidity.isValidState_of_history
+        (A := A) (S := S) (hb := hb) (StateSource := StateSource)
+        (a := a) (s := s_prev) (l := ops) ?_ ?_ h_consistent_ops h_closed_ops h_prefix h_no_dup_ops
       · exact h_source a (by simp)
-      intro x hx_lt
-      exact h_closed a x ops [] (by simp) hx_lt
-    exact Operation.stateInv_effect (A := A) a s_prev s h_stateInv_prev h_valid_a h_last
+      · intro x hx_lt
+        exact h_closed a x ops [] (by simp) hx_lt
+    exact OperationValidity.stateInv_effect (A := A) a s_prev s h_stateInv_prev h_valid_a h_last
 
 @[grind .] theorem hb_consistent_concurrent (a : A) (ops₀ ops₁ : List A) :
   hb_consistent hb (ops₀ ++ a :: ops₁) →
@@ -290,7 +299,8 @@ theorem hb_consistent_swap (ops₀ ops₁ : List A) (a b : A) :
                 simp [List.mem_append, hy]
         exact h_no_lt_x y hy' hle
 
-theorem hb_concurrent_effect_list_reorder (StateSource : A → Prop) (h_valid_mono : IsValidStateMonotone (hb := hb) StateSource)
+theorem hb_concurrent_effect_list_reorder (StateSource : A → Prop)
+  [OperationReplayValidity (A := A) (S := S) (hb := hb) StateSource]
   {s : Operation.State A} :
   (∀ x, x ∈ (ops₀ ++ a :: ops₁) → StateSource x) →
   concurrent_commutative (hb := hb) (ops₀ ++ a :: ops₁) →
@@ -317,8 +327,8 @@ theorem hb_concurrent_effect_list_reorder (StateSource : A → Prop) (h_valid_mo
         simp; assumption
       grind [Except.bind_eq_ok_exist]
     obtain ⟨ u, h_effects_eq, h_effect_b_eq ⟩ := Except.bind_eq_ok_exist h
-    have h_stateInv_u : Operation.StateInv u := by
-      apply effect_list_stateInv (hb := hb) (S := S) (StateSource := StateSource) h_valid_mono (ops := ops₀)
+    have h_stateInv_u : OperationValidity.StateInv u := by
+      apply effect_list_stateInv (hb := hb) (S := S) (StateSource := StateSource) (ops := ops₀)
       · intro x hx
         exact h_source x (by simp [hx])
       · apply hb_consistent_sublist (hb := hb) h_consistent
@@ -332,14 +342,18 @@ theorem hb_concurrent_effect_list_reorder (StateSource : A → Prop) (h_valid_mo
       . simp
       . grind [hb_concurrent_symm]
       . exact h_stateInv_u
-      . refine h_valid_mono (a := a) (s := u) (l := ops₀) ?_ ?_ ?_ ?_ h_effects_eq ?_
+      . refine OperationReplayValidity.isValidState_of_history
+          (A := A) (S := S) (hb := hb) (StateSource := StateSource)
+          (a := a) (s := u) (l := ops₀) ?_ ?_ ?_ ?_ h_effects_eq ?_
         · exact h_source a (by simp)
         · intro x hxlt
           exact h_closed a x ops₀ (b :: ops₁) (by simp [List.append_assoc]) hxlt
         · grind [hb_consistent_sublist]
         · grind [hbClosed]
         · grind [IdNoDup]
-      . refine h_valid_mono (a := b) (s := u) (l := ops₀) ?_ ?_ ?_ ?_ h_effects_eq ?_
+      . refine OperationReplayValidity.isValidState_of_history
+          (A := A) (S := S) (hb := hb) (StateSource := StateSource)
+          (a := b) (s := u) (l := ops₀) ?_ ?_ ?_ ?_ h_effects_eq ?_
         · exact h_source b (by simp)
         · intros x hxlt
           have h : ¬ a < b := by
@@ -488,7 +502,8 @@ theorem mem_ops0_prefix_iff_ops1
           (List.mem_append).2 (Or.inr hlast)
         simpa [List.append_assoc] using hx_all
 
-theorem hb_consistent_effect_convergent (StateSource : A → Prop) (h_valid_mono : IsValidStateMonotone (hb := hb) StateSource)
+theorem hb_consistent_effect_convergent (StateSource : A → Prop)
+  [OperationReplayValidity (A := A) (S := S) (hb := hb) StateSource]
   (ops₀ ops₁ : List A) (s : Operation.State A)
   (h_source₀ : ∀ x, x ∈ ops₀ → StateSource x)
   (h_source₁ : ∀ x, x ∈ ops₁ → StateSource x)
@@ -578,7 +593,7 @@ by
           have ⟨ s', ⟨ h, heq ⟩  ⟩ := Except.bind_eq_ok_exist h
           simp
           have h' := h
-          apply hb_concurrent_effect_list_reorder (hb := hb) (StateSource := StateSource) h_valid_mono at h
+          apply hb_concurrent_effect_list_reorder (hb := hb) (StateSource := StateSource) at h
           . simp at *
             rw [h', ←h]
           . intro x hx
@@ -640,8 +655,8 @@ by
             simpa [effect_list_append] using h
           have h_closed_prefix : hbClosed hb (ops₀_first ++ ops₀_last) :=
             hbClosed_remove_concurrent (hb := hb) ops₀_first ops₀_last a b hclosed₀ h_a_concurrent_ops₀_last
-          have h_stateInv_s' : Operation.StateInv s' := by
-            apply effect_list_stateInv (hb := hb) (S := S) (StateSource := StateSource) h_valid_mono (ops := ops₀_first ++ ops₀_last)
+          have h_stateInv_s' : OperationValidity.StateInv s' := by
+            apply effect_list_stateInv (hb := hb) (S := S) (StateSource := StateSource) (ops := ops₀_first ++ ops₀_last)
             · intro x hx
               exact h_source₀ x (by
                 simp [List.mem_append, List.append_assoc] at hx ⊢
@@ -674,7 +689,9 @@ by
               exact And.intro h_not_b_le_a h_not_a_le_b
             · exact h_stateInv_s'
             · -- isValidState b s'
-              refine h_valid_mono (a := b) (s := s') (l := ops₀_first ++ ops₀_last) ?_ ?_ ?_ ?_ h_eff ?_
+              refine OperationReplayValidity.isValidState_of_history
+                (A := A) (S := S) (hb := hb) (StateSource := StateSource)
+                (a := b) (s := s') (l := ops₀_first ++ ops₀_last) ?_ ?_ ?_ ?_ h_eff ?_
               · exact h_source₀ b (by simp [List.mem_append, List.append_assoc])
               · intro x hxlt
                 have h' := hclosed₀ b x (ops₀_first) (ops₀_last ++ [a]) (by simp [List.append_assoc]) hxlt
@@ -684,7 +701,9 @@ by
               · exact h_closed_prefix
               · grind [IdNoDup]
             · -- isValidState a s'
-              refine h_valid_mono (a := a) (s := s') (l := ops₀_first ++ ops₀_last) ?_ ?_ ?_ ?_ h_eff ?_
+              refine OperationReplayValidity.isValidState_of_history
+                (A := A) (S := S) (hb := hb) (StateSource := StateSource)
+                (a := a) (s := s') (l := ops₀_first ++ ops₀_last) ?_ ?_ ?_ ?_ h_eff ?_
               · exact h_source₀ a (by simp [List.mem_append, List.append_assoc])
               · intro x hxlt
                 have h' := hclosed₀ a x (ops₀_first ++ b :: ops₀_last) [] (by simp [List.append_assoc]) hxlt

--- a/LeanYjs/Network/Yjs/YjsNetwork.lean
+++ b/LeanYjs/Network/Yjs/YjsNetwork.lean
@@ -71,6 +71,8 @@ instance [DecidableEq A] : Operation (YjsOperation A) where
   | YjsOperation.insert item => state.insert item
   | YjsOperation.delete _id deletedId =>
     Except.ok <| deleteValid deletedId state
+
+instance [DecidableEq A] : OperationValidity (YjsOperation A) where
   isValidState op state := IsValidMessage state op
   StateInv state := YjsStateInvariant state
   stateInv_init := by
@@ -83,8 +85,8 @@ instance [DecidableEq A] : Operation (YjsOperation A) where
       obtain ⟨ item, hitem, hitem_valid ⟩ := h_valid
       apply YjsStateInvariant_insert s s' input h_inv hitem hitem_valid h_effect
     | delete _ deletedId =>
-      have hs' : s' = deleteById s deletedId := by
-        simpa [deleteValid] using h_effect.symm
+      have hs' : deleteById s deletedId = s' := by
+        simpa [Operation.effect, deleteValid] using h_effect
       subst hs'
       simpa [deleteById] using h_inv
 
@@ -787,11 +789,11 @@ theorem YjsOperationNetwork_concurrentCommutative {A} [DecidableEq A] (network :
     | insert bInput =>
       simp [Operation.effect, integrateValidState] at h_ab ⊢
       have h_sa_inv : YjsArrInvariant sa.toList := by
-        simpa [Operation.StateInv] using havalid
+        simpa [OperationValidity.StateInv] using havalid
       have h_a_valid_msg : ∃ aItem, aInput.toItem sa = Except.ok aItem ∧ aItem.isValid := by
-        simpa [Operation.isValidState, IsValidMessage] using hbvalid
+        simpa [OperationValidity.isValidState, IsValidMessage] using hbvalid
       have h_b_valid_msg : ∃ bItem, bInput.toItem sa = Except.ok bItem ∧ bItem.isValid := by
-        simpa [Operation.isValidState, IsValidMessage] using hab
+        simpa [OperationValidity.isValidState, IsValidMessage] using hab
       obtain ⟨ aItem, h_a_toItem, h_a_item_valid ⟩ := h_a_valid_msg
       obtain ⟨ bItem, h_b_toItem, h_b_item_valid ⟩ := h_b_valid_msg
       have h_diff_client : aInput.id.clientId ≠ bInput.id.clientId := by
@@ -3081,19 +3083,20 @@ theorem YjsOperationNetwork_converge' {A} [DecidableEq A] (network : YjsOperatio
     apply YjsOperationNetwork_concurrentCommutative network i
 
   let StateSource : YjsOperation A → Prop := fun a => ∃ i, Event.Broadcast a ∈ network.toCausalNetwork.histories i
-  have h_valid_mono : IsValidStateMonotone (A := YjsOperation A) (S := YjsId) (hb := hb) StateSource := by
-    intro a s l h_source h_lt h_consistent h_closed h_effect h_nodup
-    cases a with
-    | delete _ _ =>
-      simp [Operation.isValidState, IsValidMessage]
-    | insert input =>
-      simpa [Operation.isValidState, IsValidMessage] using
-        (isValidState_insert_from_source (network := network) (input := input) (s := s) (l := l)
-          h_source h_lt h_consistent h_closed h_effect h_nodup)
+  haveI : OperationReplayValidity (A := YjsOperation A) (S := YjsId) (hb := hb) StateSource := {
+    isValidState_of_history := by
+      intro a s l h_source h_lt h_consistent h_closed h_effect h_nodup
+      cases a with
+      | delete _ _ =>
+        simp [OperationValidity.isValidState, IsValidMessage]
+      | insert input =>
+        simpa [OperationValidity.isValidState, IsValidMessage] using
+          (isValidState_insert_from_source (network := network) (input := input) (s := s) (l := l)
+            h_source h_lt h_consistent h_closed h_effect h_nodup)
+  }
 
   have h := hb_consistent_effect_convergent (s := res₀) (hb := hb)
     StateSource
-    h_valid_mono
     (network.toCausalNetwork.toDeliverMessages i)
     (network.toCausalNetwork.toDeliverMessages j)
     (by


### PR DESCRIPTION
## Summary
- split `Operation` into core execution semantics and separate validity/invariant laws
- move replay-based validity monotonicity into `OperationReplayValidity`
- update the Yjs network instance and convergence proof to use the new classes

## Testing
- lake build LeanYjs.Network.Yjs.YjsNetwork
