### PR TITLE
refactor(Insert/Spec): make per-case proof obligations visible

### DIFF
--- a/LeanYjs/Algorithm/Insert/Spec.lean
+++ b/LeanYjs/Algorithm/Insert/Spec.lean
@@ -103,6 +103,31 @@ def extGetElemExcept (arr : Array (YjsItem A)) (idx : Int) : Except IntegrateErr
       | some item => return item
       | none => Except.error IntegrateError.error
 
+/-- Paper-aligned integration loop invariant for `findIntegratedIndex`.
+Parameters:
+- `d`: candidate destination index. Items before `d` are confirmed less than `u`.
+- `i`: current scan position. Items in `[d, i)` are pending (their order against
+  `u` is not yet resolved).
+- `scanning`: in same-origin competition mode (extending the pending region for
+  the same-origin case).
+- `done`: scan has terminated (either by `break` or by reaching `rightIdx`).
+
+Mirrors the paper's Definition (\\S Insert Algorithm and Commutativity). -/
+structure IntegrationInvariant (arr : Array (YjsItem A)) (u : YjsItem A)
+    (d i : ℕ) (scanning done : Bool) : Prop where
+  /-- All items before the candidate destination are strictly smaller than `u`. -/
+  prefixLt : ∀ j, j < d → (hj : j < arr.size) → YjsLt' (A := A) arr[j] u
+  /-- Each pending item in `[d, i)` either shares origin with `u` (and lost the
+  ID tiebreak) or has an origin reachable above `arr[d]`. -/
+  scannedRegion : ∀ j, d ≤ j → j < i →
+    ∃ (hj : j < arr.size) (hd : d < arr.size),
+      (arr[j].origin = u.origin ∧ u.id < arr[j].id) ∨
+      YjsLeq' (A := A) (YjsPtr.itemPtr arr[d]) arr[j].origin
+  /-- Same-origin competition mode: `arr[d]` shares its origin with `u`. -/
+  scanningOrigin : scanning → ∃ (hd : d < arr.size), arr[d].origin = u.origin
+  /-- On termination, `u` is strictly smaller than the boundary item `arr[i]`. -/
+  doneLt : done → (hi : i < arr.size) → YjsLt' (A := A) u arr[i]
+
 def loopInv (arr : Array (YjsItem A)) (newItem : YjsItem A) (leftIdx : ℤ) (rightIdx : ℤ) (x : Option ℕ) (state : ForInStep (MProd ℤ Bool)) :=
   -- when x is none, we are done so current is rightIdx
   -- when break from loop, current goes back by 1
@@ -138,55 +163,73 @@ omit [DecidableEq A] in theorem not_rightOrigin_first (P : YjsPtr A -> Prop) (it
   rw [heq] at hlt
   apply not_ptr_lt_first hclosed hinv _ _ hin at hlt; assumption
 
--- 補題: itemとの大小関係が保留の区間 [dest, i) newItem < arr[i]なら∀j ∈ [dest, i) でnewItem < arr[j]が成り立つ。
--- つまりループの終了条件が満たされたら[dest, i)のすべてでnewItem < arr[j]
-theorem loopInv_YjsLt' {current} offset (arr : Array (YjsItem A)) (newItem : YjsItem A) (leftIdx rightIdx : ℤ) (state : ForInStep (MProd ℤ Bool)) :
-  IsClosedItemSet (ArrSet (newItem :: arr.toList)) ->
-  ItemSetInvariant (ArrSet (newItem :: arr.toList)) ->
-  YjsArrInvariant arr.toList ->
-  loopInv arr newItem leftIdx rightIdx offset state ->
+-- Bridge from the internal `loopInv` encoding to the paper-aligned `IntegrationInvariant`.
+theorem loopInv_to_IntegrationInvariant
+    {arr : Array (YjsItem A)} {newItem : YjsItem A}
+    {leftIdx rightIdx : ℤ} {x : Option ℕ} {state : ForInStep (MProd ℤ Bool)}
+    (h : loopInv arr newItem leftIdx rightIdx x state)
+    (hright : findPtrIdx newItem.rightOrigin arr = Except.ok rightIdx)
+    (hrightIdx : 0 ≤ rightIdx) :
+    IntegrationInvariant arr newItem
+      state.value.fst.toNat
+      (offsetToIndex leftIdx rightIdx x (isBreak state))
+      state.value.snd
+      (isDone state x) := by
+  unfold loopInv at h
+  obtain ⟨ _, _, _, hprefix, hscanned, hscanOrigin, hdoneLt ⟩ := h
+  exact {
+    prefixLt := by simpa using hprefix
+    scannedRegion := by simpa using hscanned
+    scanningOrigin := by simpa using hscanOrigin
+    doneLt := by
+      intro hdone hi
+      refine hdoneLt hdone _ ?_
+      simp [extGetElemExcept]
+      rw [Array.getElem?_eq_getElem (by omega)]
+      simp
+      split <;> [omega; skip]
+      split <;> [omega; skip]
+      rfl
+  }
 
-  findPtrIdx newItem.origin arr = Except.ok leftIdx ->
-  findPtrIdx newItem.rightOrigin arr = Except.ok rightIdx ->
-
-  current = offsetToIndex leftIdx rightIdx offset (isBreak state) ->
-  (hcurrentlt : current ≤ arr.size) ->
-  ((hlt : current < arr.size) -> YjsLt' (A := A) newItem arr[current]) ->
-  ∀ j : ℕ, (h_j_dest : state.value.fst ≤ j) ->
-    (h_j_i : j ≤ current) -> (h_j_size : j < arr.size) ->
-    YjsLt' (A := A) newItem arr[j] := by
-
-  intros hclosed hinv harrinv hloopinv hleftIdx hrightIdx hcurrent hcurrent_lt hi_lt j h_j_dest h_j_i h_j_size
+/-- Pending propagation (paper Lemma): if at scan position `i` the
+`IntegrationInvariant` holds and `u <_Y arr[i]`, then `u <_Y arr[j]`
+for every pending position `j ∈ [d, i]`. -/
+theorem pending_propagation
+  (arr : Array (YjsItem A)) (u : YjsItem A)
+  (leftIdx rightIdx : ℤ) (d i : ℕ)
+  (hclosed : IsClosedItemSet (ArrSet (u :: arr.toList)))
+  (hinv : ItemSetInvariant (ArrSet (u :: arr.toList)))
+  (harrinv : YjsArrInvariant arr.toList)
+  (hleftIdx : findPtrIdx u.origin arr = Except.ok leftIdx)
+  (hrightIdx : findPtrIdx u.rightOrigin arr = Except.ok rightIdx)
+  (hi_le_ri : ↑i ≤ rightIdx)
+  (hscanned : ∀ j, d ≤ j → j < i →
+    ∃ (hj : j < arr.size) (hd : d < arr.size),
+      (arr[j].origin = u.origin ∧ u.id < arr[j].id) ∨
+      YjsLeq' (A := A) (YjsPtr.itemPtr arr[d]) arr[j].origin)
+  (hi_le : i ≤ arr.size)
+  (hi_lt : (h : i < arr.size) → YjsLt' (A := A) u arr[i]) :
+  ∀ j : ℕ, d ≤ j → j ≤ i → (h_j_size : j < arr.size) →
+    YjsLt' (A := A) u arr[j] := by
+  intros j h_j_d h_j_i h_j_size
   generalize hsize : arr[j].size = size
   revert j
-  generalize h_dest_def : state.value.fst = dest
-  generalize h_scanning : state.value.snd = scanning
-  apply Nat.strongRec' (p := fun size => ∀ (j : ℕ), dest ≤ j → (h_j_i : j ≤ current) -> (h_j_size : j < arr.size) -> arr[j].size = size → YjsLt' (A := A) newItem (YjsPtr.itemPtr arr[j]))
-  intros n ih j h_j_dest h_j_i h_j_size heq_n
-  wlog h_j_i : j < current
+  apply Nat.strongRec' (p := fun size => ∀ (j : ℕ),
+    d ≤ j → (h_j_i : j ≤ i) → (h_j_size : j < arr.size) →
+    arr[j].size = size → YjsLt' (A := A) u (YjsPtr.itemPtr arr[j]))
+  intros n ih j h_j_d h_j_i h_j_size heq_n
+  wlog h_j_i : j < i
   case inr =>
-    have h_j_eq : j = current := by
-      omega
-    subst j
-    apply hi_lt
-
+    have h_j_eq : j = i := by omega
+    subst j; exact hi_lt h_j_size
   subst heq_n
-  unfold loopInv at hloopinv
-  have heq : state.value = ⟨dest, scanning⟩ := by
-    subst h_dest_def
-    subst h_scanning
-    cases state <;> eq_refl
-  rw [heq] at hloopinv
-  obtain ⟨ hsize, hdest_current, h_not_scanning, h_lt_item, h_tbd, h_cand, h_done ⟩ := hloopinv
-  -- simp [offsetToIndex] at h_tbd hcurrent
-  subst hcurrent
-  obtain ⟨ h_j_lt_size, h_dest_lt_size, h_tbd ⟩ := h_tbd j (by omega) h_j_i
+  obtain ⟨ h_j_lt_size, h_d_lt_size, h_tbd ⟩ := hscanned j (by omega) h_j_i
   cases h_tbd with
   | inl h_origin =>
     obtain ⟨ h_origin_eq, h_id_lt ⟩ := h_origin
-
-    have ⟨ _, hlt_ro ⟩ : YjsLt' (A := A) newItem arr[j].rightOrigin := by
-      generalize h_ro_eq : arr[j].rightOrigin = ro at heq
+    have ⟨ _, hlt_ro ⟩ : YjsLt' (A := A) u arr[j].rightOrigin := by
+      generalize h_ro_eq : arr[j].rightOrigin = ro
       cases ro with
       | first =>
         apply not_rightOrigin_first _ arr[j] hclosed hinv at h_ro_eq
@@ -199,162 +242,106 @@ theorem loopInv_YjsLt' {current} offset (arr : Array (YjsItem A)) (newItem : Yjs
       | itemPtr ro =>
         have ⟨ roIdx, h_ro_in ⟩ : ∃ k : Fin arr.size, arr[k] = ro := by
           cases arr_set_closed_exists_index_for_right_origin arr.toList arr[j] (harrinv.closed) (by simp [ArrSet]) with
-          | inl h1 =>
-            rw [h_ro_eq] at h1
-            cases h1
+          | inl h1 => rw [h_ro_eq] at h1; cases h1
           | inr h =>
             cases h with
-            | inl h1 =>
-              rw [h_ro_eq] at h1
-              cases h1
+            | inl h1 => rw [h_ro_eq] at h1; cases h1
             | inr h1 =>
               rw [h_ro_eq] at h1
-              obtain ⟨ k, h1 ⟩ := h1
-              cases h1
-              exists k
-
+              obtain ⟨ k, h1 ⟩ := h1; cases h1; exists k
         have hsize : ro.size < arr[j].size := by
           revert h_ro_eq
-          obtain ⟨ o, r, id, c ⟩ := arr[j]
-          simp
-          intros h_ro_eq
-          subst h_ro_eq
-          simp [YjsItem.size, YjsPtr.size]
-          omega
-
-        have h_dest_k : dest.toNat ≤ roIdx := by
-          obtain ⟨ roIdx, _ ⟩ := roIdx
-          simp at *
+          obtain ⟨ o, r, id, c ⟩ := arr[j]; simp
+          intros h_ro_eq; subst h_ro_eq
+          simp [YjsItem.size, YjsPtr.size]; omega
+        have h_d_k : d ≤ roIdx := by
+          obtain ⟨ roIdx, _ ⟩ := roIdx; simp at *
           have hlt : j < roIdx := by
             have hlt : YjsLt' (A := A) arr[j] arr[roIdx] := by
               rw [h_ro_in]
               generalize heq : arr[j] = arrj at *
               obtain ⟨ o, r, id, c ⟩ := arrj
-              simp at h_ro_eq
-              subst h_ro_eq
+              simp at h_ro_eq; subst h_ro_eq
               exists 1
-              have harrin : ArrSet arr.toList (YjsItem.mk o (YjsPtr.itemPtr ro) id c) := by
-                rw [<-heq]
-                simp [ArrSet]
-              apply YjsLt.ltRightOrigin
-              apply YjsLeq.leqSame
-
-            have hltj : j < arr.size := by
-              omega
-            have hltk : roIdx < arr.size := by
-              omega
-            apply getElem_YjsLt'_index_lt arr j roIdx harrinv hltj hltk hlt
+              apply YjsLt.ltRightOrigin; apply YjsLeq.leqSame
+            apply getElem_YjsLt'_index_lt arr j roIdx harrinv (by omega) (by omega) hlt
           omega
-
-        cases Nat.lt_or_ge roIdx (offsetToIndex leftIdx rightIdx offset (isBreak state)) with
-        | inl h_k_current =>
-          obtain x := ih (ro.size) hsize roIdx (by omega) (by omega) (by omega) (by rw [<-h_ro_in]; simp)
-          simp at h_ro_in x
-          rw [h_ro_in] at x
-          assumption
-        | inr h_k_current =>
-          -- newItem < arr[current] <= arr[k]
-          have hlt : YjsLeq' (A := A) arr[offsetToIndex leftIdx rightIdx offset (isBreak state)] ro := by
+        cases Nat.lt_or_ge roIdx i with
+        | inl h_k_i =>
+          obtain x := ih (ro.size) hsize roIdx (by omega) (by omega) (by omega) (by rw [←h_ro_in]; simp)
+          simp at h_ro_in x; rw [h_ro_in] at x; assumption
+        | inr h_k_i =>
+          have h_roIdx_lt : (roIdx : ℕ) < arr.size := roIdx.isLt
+          have hlt : YjsLeq' (A := A) arr[i] ro := by
             subst h_ro_in
-            apply getElem_leq_YjsLeq' arr (offsetToIndex leftIdx rightIdx offset (isBreak state)) roIdx harrinv (by omega) (by omega)
+            apply getElem_leq_YjsLeq' arr i roIdx harrinv (by omega) (by omega)
           apply yjs_leq'_p_trans2 hinv _ _ _ _ _ _ hclosed (hi_lt (by omega)) hlt
-          . simp [ArrSet]
-          . simp [ArrSet]
-          . subst ro; simp [ArrSet]
-
-    have ⟨ _, hlt_ro' ⟩ : YjsLt' (A := A) arr[j] newItem.rightOrigin := by
-      have hlt : j < rightIdx := by
-        cases offset <;> simp [offsetToIndex] at h_j_i <;> omega
-      have heq : findPtrIdx arr[j] arr = Except.ok j := by
+          · simp [ArrSet]
+          · simp [ArrSet]
+          · subst ro; simp [ArrSet]
+    have ⟨ _, hlt_ro' ⟩ : YjsLt' (A := A) arr[j] u.rightOrigin := by
+      have hlt : ↑j < rightIdx := by omega
+      have heq : findPtrIdx (A := A) arr[j] arr = Except.ok ↑j := by
         apply findPtrIdx_getElem; assumption
       apply findPtrIdx_lt_YjsLt' _ _ _ harrinv heq hrightIdx hlt
-
-    obtain ⟨ o, r, id, c ⟩ := newItem
+    obtain ⟨ o, r, id, c ⟩ := u
     generalize arr[j] = item at *
     obtain ⟨ oo, or, oid, oc ⟩ := item
     simp at h_origin_eq hlt_ro hlt_ro'
-    rw [h_origin_eq]
-    rw [h_origin_eq] at hlt_ro'
+    rw [h_origin_eq]; rw [h_origin_eq] at hlt_ro'
     constructor
     apply YjsLt.ltConflict
     apply ConflictLt.ltOriginSame <;> try assumption
   | inr hleq =>
-    have hlt_ro : YjsLt' (A := A) newItem arr[j].origin := by
-      generalize h_o_eq : arr[j].origin = o at heq
+    have hlt_ro : YjsLt' (A := A) u arr[j].origin := by
+      generalize h_o_eq : arr[j].origin = o
       cases o with
       | first =>
         rw [h_o_eq] at hleq
         apply yjs_leq'_imp_eq_or_yjs_lt' at hleq
         cases hleq with
-        | inl heq =>
-          cases heq
+        | inl heq => cases heq
         | inr hlt =>
           by_contra
           apply not_ptr_lt'_first hclosed hinv at hlt; assumption
           simp [ArrSet]
-
       | last =>
-        constructor
-        apply YjsLt.ltOriginOrder
-        apply OriginLt.lt_last
+        constructor; apply YjsLt.ltOriginOrder; apply OriginLt.lt_last
       | itemPtr o =>
-        have ⟨ ⟨ oIdx, _ ⟩ , h_o_in ⟩ : ∃ k : Fin arr.size, arr[k] = o := by
+        have ⟨ ⟨ oIdx, h_oIdx_lt ⟩, h_o_in ⟩ : ∃ k : Fin arr.size, arr[k] = o := by
           cases arr_set_closed_exists_index_for_origin arr.toList arr[j] (harrinv.closed) (by simp [ArrSet]) with
-          | inl h1 =>
-            rw [h_o_eq] at h1
-            cases h1
+          | inl h1 => rw [h_o_eq] at h1; cases h1
           | inr h =>
             cases h with
-            | inl h1 =>
-              rw [h_o_eq] at h1
-              cases h1
+            | inl h1 => rw [h_o_eq] at h1; cases h1
             | inr h1 =>
               rw [h_o_eq] at h1
-              obtain ⟨ k, h1 ⟩ := h1
-              cases h1
-              exists k
-
+              obtain ⟨ k, h1 ⟩ := h1; cases h1; exists k
         have hsize : o.size < arr[j].size := by
           revert h_o_eq
-          obtain ⟨ o, r, id, c ⟩ := arr[j]
-          simp
-          intros h_o_eq
-          subst h_o_eq
-          simp [YjsItem.size, YjsPtr.size]
-          omega
-
-        have h_dest_k : dest ≤ oIdx := by
-          simp at *
-          rw [h_o_eq] at hleq
+          obtain ⟨ o, r, id, c ⟩ := arr[j]; simp
+          intros h_o_eq; subst h_o_eq
+          simp [YjsItem.size, YjsPtr.size]; omega
+        have h_d_k : d ≤ oIdx := by
+          suffices h : (↑d : ℤ) ≤ ↑oIdx by omega
           subst h_o_in
-
-          have hor : dest < 0 ∨ 0 ≤ dest := by
-            apply Int.lt_or_le
-          cases hor with
-          | inl _ => omega
-          | inr _ =>
-            apply YjsLeq'_findPtrIdx_leq _ _ _ _ _ harrinv _ _ hleq
-            . rw [findPtrIdx_getElem _ _ harrinv]
-              simp
-              omega
-            . rw [findPtrIdx_getElem _ _ harrinv]
-            . simp [ArrSet]
-            . simp [ArrSet]
-
-        simp at h_o_in
-        subst h_o_in
-        apply ih arr[oIdx].size hsize _ h_dest_k
-        . simp
-        . have hlt : oIdx < j := by
+          rw [h_o_eq] at hleq
+          have hleq' : YjsLeq' (A := A) (YjsPtr.itemPtr arr[d]) (YjsPtr.itemPtr arr[oIdx]) := hleq
+          apply YjsLeq'_findPtrIdx_leq _ _ _ _ _ harrinv _ _ hleq'
+          · rw [findPtrIdx_getElem _ _ harrinv]
+          · rw [findPtrIdx_getElem _ _ harrinv]
+          · simp [ArrSet]
+          · simp [ArrSet]
+        simp at h_o_in; subst h_o_in
+        apply ih arr[oIdx].size hsize _ (by omega)
+        · simp
+        · have hlt : oIdx < j := by
             apply getElem_YjsLt'_index_lt arr oIdx j harrinv (by omega) (by omega)
-            rw [<-h_o_eq]
+            rw [←h_o_eq]
             generalize heq : arr[j] = arrj at *
-            obtain ⟨ o, r, id, c ⟩ := arrj
-            simp
-            apply YjsLt'.ltOrigin
-            apply YjsLeq'.leqSame
+            obtain ⟨ o, r, id, c ⟩ := arrj; simp
+            apply YjsLt'.ltOrigin; apply YjsLeq'.leqSame
           omega
-
     generalize heq : arr[j] = arrj at *
     obtain ⟨ o, r, id, c ⟩ := arrj
     apply YjsLt'.ltOrigin (A := A)
@@ -1706,38 +1693,38 @@ theorem YjsArrInvariant_integrate (input : IntegrateInput A) (arr newArr : Array
           obtain ⟨ hidx, dest, hdest, hlt, htbd1, htbd2, hdone ⟩ := hloopInv
           apply findPtrIdx_le_size at heqright'
           cases offset <;> simp [offsetToIndex] <;> omega
+        have h_i_le_ri : (↑(offsetToIndex leftIdx rightIdx offset (isBreak res')) : ℤ) ≤ rightIdx := by
+          obtain ⟨ hidx, _, _, _, _, _, _ ⟩ := hloopInv
+          cases offset <;> simp [offsetToIndex, isBreak] at * <;> omega
+        have h_done_flag : isDone res' offset = true := by
+          cases hdone with
+          | inl h => subst h; simp [isDone]
+          | inr h => subst h; simp [isDone]
+        have hii := loopInv_to_IntegrationInvariant
+          (rightIdx := ↑rightIdx.toNat) hloopInv
+          (by simpa [Int.max_eq_left hrightIdx] using heqright')
+          (by exact_mod_cast Nat.zero_le _)
         intros hisize
-        apply loopInv_YjsLt' (current := offsetToIndex leftIdx rightIdx offset (isBreak res')) <;> try assumption
-        . simp
-          rw [max_eq_left hrightIdx]
-          assumption
-        . simp
-          rw [max_eq_left hrightIdx]
-        . intros hlt
-          simp [loopInv] at hloopInv
-          obtain ⟨ hidx, hdest_current, hdestLt, hlt', htbd1, htbd2, hdone' ⟩ := hloopInv
-          apply hdone'
-          . cases hdone with
-            | inl hdone =>
-              subst hdone
-              simp [isDone]
-            | inr hdone =>
-              subst hdone
-              simp [isDone]
-          . rw [max_eq_left hrightIdx]
-            simp [extGetElemExcept]
-            rw [Array.getElem?_eq_getElem (by omega)]
-            simp
-            split; omega
-            split; omega
-            eq_refl
-        . subst hres'
-          simp
-        . subst hres'
+        have h_dest_le_current : resState.fst.toNat ≤
+            offsetToIndex leftIdx rightIdx offset (isBreak res') := by
+          subst hres'
           obtain ⟨ hidx, hdest_current, hdestLt, hlt', htbd1, htbd2, hdone' ⟩ := hloopInv
           simp at *
           rw [Int.max_eq_left hrightIdx] at hdest_current
           obtain ⟨ _, _ ⟩ | ⟨ _, _ ⟩ := res' <;> simp at * <;> omega
+        apply pending_propagation arr newItem leftIdx rightIdx
+          resState.fst.toNat (offsetToIndex leftIdx rightIdx offset (isBreak res'))
+          hclosed harrsetinv harrinv heqleft' heqright'
+          h_i_le_ri
+          (by simpa [Int.max_eq_left hrightIdx, hres'] using hii.scannedRegion)
+          current_lt
+          (fun hlt => by
+            simpa [Int.max_eq_left hrightIdx] using
+              hii.doneLt (by simpa [Int.max_eq_left hrightIdx] using h_done_flag) hlt)
+          resState.fst.toNat
+          (le_refl _)
+          h_dest_le_current
+          hisize
       . intros a hmem heq
         have h := h_maximalId a (by simp [ArrSet]; assumption) (by rw [heq])
         rw [heq] at h

--- a/LeanYjs/Algorithm/Insert/Spec.lean
+++ b/LeanYjs/Algorithm/Insert/Spec.lean
@@ -381,7 +381,21 @@ theorem offsetToIndex_range'_getElem {leftIdx rightIdx : ℤ} {offset : ℕ} :
     rw [List.length_range'] at h_length
     omega
 
-theorem dest_lt_YjsLt'_preserve {A : Type} [inst : DecidableEq A] (newItem : YjsItem A) (arr : Array (YjsItem A))
+/-- Preservation of `IntegrationInvariant.prefixLt`: every position before the
+new candidate destination is still strictly less than `newItem`.
+
+Case structure (paper §"Preservation"):
+* breakLeftOrigin (`oLeftIdx < leftIdx`, Lines 9–10): `nDest = dest` ⇒ trivial.
+* advanceSameOrigin (`oLeftIdx = leftIdx`, `other.id < newItem.id`, Lines 12–13):
+  `nDest = i+1`. Real obligation: show `arr[i] < newItem` via `ConflictLt.ltOriginSame`.
+* breakSameRight (`oLeftIdx = leftIdx`, `oRightIdx = rightIdx`, Lines 14–15):
+  `nDest = dest` ⇒ trivial.
+* pendingSameOrigin (`oLeftIdx = leftIdx`, `oRightIdx ≠ rightIdx`, Lines 16–17):
+  `nDest = dest` ⇒ trivial.
+* advanceOtherOrigin (`oLeftIdx > leftIdx`, `¬scanning`):
+  `nDest = i+1`. Real obligation: show `arr[i] < newItem` via origin transitivity
+  through `arr[dest]` (no_cross_origin then prefixLt of old). -/
+theorem loopInv_prefixLt_preserve {A : Type} [inst : DecidableEq A] (newItem : YjsItem A) (arr : Array (YjsItem A))
   (horigin : ArrSet arr.toList newItem.origin) (hrorigin : ArrSet arr.toList newItem.rightOrigin)
   (horigin_consistent : YjsLt' (A := A) newItem.origin newItem.rightOrigin)
   (hreachable_consistent :
@@ -473,10 +487,15 @@ theorem dest_lt_YjsLt'_preserve {A : Type} [inst : DecidableEq A] (newItem : Yjs
     apply findPtrIdx_lt_YjsLt' (i := (leftIdx + (1 + ↑i)).toNat) (j := rightIdx) <;> try assumption
     . subst other; rw [findPtrIdx_getElem]; assumption
     . omega
+  -- Discharge cases where j is in the OLD prefix region (nDest = dest):
+  --   breakLeftOrigin / breakSameRight / pendingSameOrigin / pendingOtherOrigin.
   split at h_j_lt <;> try (apply h_j_dest (by omega))
   split at h_j_lt
-  . split at h_j_lt
+  . -- oLeftIdx = leftIdx branch
+    split at h_j_lt
     on_goal 2 => apply h_j_dest (by omega)
+    -- ► Case advanceSameOrigin (Lines 12–13): nDest = i+1.
+    -- Show arr[i] < newItem via ConflictLt.ltOriginSame (same origin, newItem.id wins).
     apply yjs_leq'_p_trans1 (inv := harrsetinv) (y := other) <;> try assumption
     . simp [ArrSet]
     . subst other; simp [ArrSet]
@@ -497,9 +516,11 @@ theorem dest_lt_YjsLt'_preserve {A : Type} [inst : DecidableEq A] (newItem : Yjs
       exists 0; apply YjsLeq.leqSame
     . intros; simp; right; assumption
     . simp
-  . -- leftIdx < oLeftIdx cases
+  . -- oLeftIdx > leftIdx branch
     split at h_j_lt
-    . apply yjs_leq'_p_trans1 (inv := harrsetinv) (y := other) <;> try assumption
+    . -- ► Case advanceOtherOrigin (Otherwise, ¬scanning): nDest = i+1.
+      -- Show arr[i] < newItem via origin transitivity (no_cross_origin then old prefix).
+      apply yjs_leq'_p_trans1 (inv := harrsetinv) (y := other) <;> try assumption
       . simp [ArrSet]
       . simp [ArrSet]
       . subst other
@@ -554,6 +575,7 @@ theorem dest_lt_YjsLt'_preserve {A : Type} [inst : DecidableEq A] (newItem : Yjs
             omega
         . intros; simp; right; assumption
         . simp
+    -- ► Case pendingOtherOrigin (Otherwise, scanning): nDest = dest, fall through.
     apply h_j_dest (by omega)
 
 
@@ -570,7 +592,22 @@ omit [DecidableEq A] in theorem idx_between_id_neq {i : ℕ} {newItem other : Yj
   have h := h (by simp)
   omega
 
-theorem nDest_geq_i_lt_current_arr_i_origin_eq_newItem_origin_or_arr_nDest_lt_arr_i_origin {A : Type}
+/-- Preservation of `IntegrationInvariant.scannedRegion`: every position in the
+new pending region `[nDest, newCurrent)` either shares origin with `newItem`
+(losing the ID tiebreak) or has an origin reachable from `arr[nDest]`.
+
+Case structure (paper §"Preservation"):
+* breakLeftOrigin / breakSameRight: the current cursor steps back by 1 due to
+  `break`; the pending region stays the same as before. Inherit from old `h_tbd`.
+* advanceSameOrigin / advanceOtherOrigin: `nDest = i+1 = newCurrent`. The
+  pending region is empty. Discharged by omega.
+* pendingSameOrigin (Lines 16–17): nDest = dest. The new pending position is
+  `arr[i]` itself. Show clause (a): `arr[i].origin = newItem.origin` (since
+  `oLeftIdx = leftIdx`) and `newItem.id < arr[i].id` (from id_total + sameid_consistent).
+* pendingOtherOrigin (Otherwise, scanning): nDest = dest. The new pending
+  position is `arr[i]`. Show clause (b): `arr[dest] ≤ arr[i].origin` via
+  `no_cross_origin` applied to the comparison `arr[dest] < arr[i]` (from sortedness). -/
+theorem loopInv_scannedRegion_preserve {A : Type}
   [inst : DecidableEq A] (newItem : YjsItem A) (arr : Array (YjsItem A))
   (hsameid_consistent : ∀ (x : YjsItem A),
     ArrSet arr.toList (YjsPtr.itemPtr x) → x.id.clientId = newItem.id.clientId → x.id.clock < newItem.id.clock)
@@ -653,7 +690,8 @@ theorem nDest_geq_i_lt_current_arr_i_origin_eq_newItem_origin_or_arr_nDest_lt_ar
   exists h_j_lt_arr_size, nDest_lt_arr_size
   rw [offsetToIndex_range'_getElem (by assumption) (by assumption) (by omega)] at h_i_c
   split at hbody
-  . -- break case (oLeftIdx < leftIdx)
+  . -- ► Case breakLeftOrigin (Lines 9–10): nDest = dest, nScanning = scanning.
+    -- The pending region is unchanged (current shifts back by 1 due to break).
     have ⟨ heq1, heq2 ⟩ : nDest = dest ∧ nScanning = scanning := by
       subst next; cases hnexteq; simp
     subst next heq1 heq2
@@ -662,17 +700,17 @@ theorem nDest_geq_i_lt_current_arr_i_origin_eq_newItem_origin_or_arr_nDest_lt_ar
     obtain ⟨ _, _, h_tbd ⟩ := h_tbd j (by assumption) (by omega)
     apply h_tbd
   . split at hbody
-    . -- oLeftIdx = leftIdx case
+    . -- oLeftIdx = leftIdx branch
       split at hbody
-      . -- other.id < newItem.id case
+      . -- ► Case advanceSameOrigin (Lines 12–13): nDest = i+1 = newCurrent.
+        -- Pending region is empty; goal closed by omega.
         have ⟨ heq1, heq2 ⟩ : nDest = leftIdx + (1 + ↑i) + 1 ∧ nScanning = false := by
           subst next; cases hnexteq; simp
         subst next heq1 heq2
         simp [isBreak] at h_i_c
         omega
-      . -- other.id >= newItem.id case
-        split at hbody
-        . -- oRightIdx = rightIdx case
+      . split at hbody
+        . -- ► Case breakSameRight (Lines 14–15): nDest = dest, nScanning = scanning.
           have ⟨ heq1, heq2 ⟩ : nDest = dest ∧ nScanning = scanning := by
             subst next; cases hnexteq; simp
           subst next heq1 heq2
@@ -680,7 +718,10 @@ theorem nDest_geq_i_lt_current_arr_i_origin_eq_newItem_origin_or_arr_nDest_lt_ar
           simp [offsetToIndex, isBreak] at h_tbd
           obtain ⟨ _, _, h_tbd ⟩ := h_tbd j (by omega) (by omega)
           apply h_tbd
-        . -- oRightIdx ≠ rightIdx case
+        . -- ► Case pendingSameOrigin (Lines 16–17): nDest = dest, nScanning := true.
+          -- New pending position is `arr[i]`; show clause (a):
+          --   `arr[i].origin = newItem.origin` (oLeftIdx = leftIdx)
+          --   ∧ `newItem.id < arr[i].id` (id_total + sameid_consistent).
           have ⟨ heq1, heq2 ⟩ : nDest = dest ∧ nScanning = true := by
             subst next; cases hnexteq; simp
           subst next heq1 heq2
@@ -723,15 +764,18 @@ theorem nDest_geq_i_lt_current_arr_i_origin_eq_newItem_origin_or_arr_nDest_lt_ar
                 | inr heq_id =>
                   rw [heq_id] at hneq
                   contradiction
-    . -- oLeftIdx > leftIdx case
+    . -- oLeftIdx > leftIdx branch
       split at hbody
-      . -- scanning = false case
+      . -- ► Case advanceOtherOrigin (Otherwise, ¬scanning): nDest = i+1.
+        -- Pending region is empty.
         have ⟨ heq1, heq2 ⟩ : nDest = leftIdx + (1 + ↑i) + 1 ∧ nScanning = scanning := by
           subst next; cases hnexteq; simp
         subst next heq1 heq2
         simp [isBreak] at h_i_c
         omega
-      . -- scanning = true case
+      . -- ► Case pendingOtherOrigin (Otherwise, scanning): nDest = dest, nScanning = true.
+        -- New pending position is `arr[i]`; show clause (b):
+        --   `arr[dest] ≤ arr[i].origin` via `no_cross_origin` on `arr[dest] < arr[i]`.
         have ⟨ heq1, heq2 ⟩ : nDest = dest ∧ nScanning = true := by
             subst next; cases hnexteq; simp
             cases scanning
@@ -812,7 +856,17 @@ theorem nDest_geq_i_lt_current_arr_i_origin_eq_newItem_origin_or_arr_nDest_lt_ar
 
             omega
 
-theorem scanning_dest_origin_eq_newItem_origin_preserve {A : Type} [inst : DecidableEq A] (newItem : YjsItem A)
+/-- Preservation of `IntegrationInvariant.scanningOrigin`: when the new
+`scanning` flag is true, `arr[nDest]` shares its origin with `newItem`.
+
+Case structure:
+* breakLeftOrigin / breakSameRight / advanceOtherOrigin / pendingOtherOrigin:
+  scanning unchanged ⇒ inherit from `h_cand`.
+* advanceSameOrigin: nScanning = false ⇒ vacuous.
+* pendingSameOrigin (Lines 16–17): only this case can SET scanning from false
+  to true. New `arr[nDest] = arr[dest] = arr[i]` (since `dest = i` when not
+  scanning), and `arr[i].origin = newItem.origin` (oLeftIdx = leftIdx). -/
+theorem loopInv_scanningOrigin_preserve {A : Type} [inst : DecidableEq A] (newItem : YjsItem A)
   (arr : Array (YjsItem A))
   (leftIdx : ℤ)
   (heqleft : findPtrIdx newItem.origin arr = Except.ok leftIdx) (rightIdx : ℤ) (next : ForInStep (MProd ℤ Bool))
@@ -874,16 +928,23 @@ theorem scanning_dest_origin_eq_newItem_origin_preserve {A : Type} [inst : Decid
   nScanning = true → ∃ (h_dest_lt : nDest.toNat < arr.size), arr[nDest.toNat].origin = newItem.origin := by
   intros h_scanning
   split at hbody; rw [hbody] at hnexteq; cases hnexteq
-  . apply h_cand h_scanning
+  . -- ► Case breakLeftOrigin: nScanning = scanning, inherit.
+    apply h_cand h_scanning
   split at hbody
   . split at hbody; rw [hbody] at hnexteq; cases hnexteq
-    . contradiction
+    . -- ► Case advanceSameOrigin: nScanning = false, contradicts h_scanning.
+      contradiction
     . split at hbody <;> (rw [hbody] at hnexteq; cases hnexteq)
-      . apply h_cand h_scanning
+      . -- ► Case breakSameRight: nScanning = scanning, inherit.
+        apply h_cand h_scanning
       . cases scanning with
         | true =>
+          -- ► Case pendingSameOrigin (was already scanning): inherit.
           apply h_cand h_scanning
         | false =>
+          -- ► Case pendingSameOrigin (newly entered scanning):
+          -- arr[nDest] = arr[dest] = arr[i] (since dest = i when not scanning),
+          -- and arr[i].origin = newItem.origin (oLeftIdx = leftIdx).
           have h_dest_eq : dest = ↑(offsetToIndex leftIdx (rightIdx ⊔ 0) (some (1 + i)) false) := by
             apply h_not_scanning (by simp)
             simp [isDone]
@@ -896,11 +957,31 @@ theorem scanning_dest_origin_eq_newItem_origin_preserve {A : Type} [inst : Decid
           rw [heq]
           apply findPtrIdx_eq_ok_inj _ _ hoLeftIdx heqleft
   split at hbody <;> (rw [hbody] at hnexteq; cases hnexteq)
-  . subst scanning
+  . -- ► Case advanceOtherOrigin: nScanning = scanning = false, contradicts.
+    subst scanning
     contradiction
-  . apply h_cand h_scanning
+  . -- ► Case pendingOtherOrigin: nScanning = scanning, inherit.
+    apply h_cand h_scanning
 
-theorem isDone_true_newItem_lt_item {A : Type} [inst : DecidableEq A] (newItem : YjsItem A) (arr : Array (YjsItem A))
+/-- Preservation of `IntegrationInvariant.doneLt`: when the new state is done
+(either by `break` or by reaching `rightIdx`), `newItem` is strictly less than
+the boundary item.
+
+Case structure:
+* breakLeftOrigin (Lines 9–10): `next = .done` because `oLeftIdx < leftIdx`.
+  Boundary item is `arr[i] = other`. Show `newItem < other` via `no_cross_origin`
+  (other.origin must be ≤ newItem.origin or ≥ newItem.rightOrigin; combined with
+  `oLeftIdx < leftIdx`, only `other ≤ newItem.origin < newItem` is consistent —
+  but that gives the desired comparison).
+* advanceSameOrigin / pendingSameOrigin / advanceOtherOrigin: `next = .yield`,
+  so done remains determined by the offset; vacuous unless `offset = none`.
+* breakSameRight (Lines 14–15): `next = .done`. Boundary item is `other`.
+  Show via `ConflictLt.ltOriginSame` (same origin and same right-origin
+  ⇒ id_total + sameid_consistent gives `newItem.id < other.id`).
+* pendingOtherOrigin (Otherwise, scanning): `next = .yield`. Done only if
+  loop has reached `rightIdx` (`offset = none` after this iteration). Boundary
+  item is `newItem.rightOrigin`. -/
+theorem loopInv_doneLt_preserve {A : Type} [inst : DecidableEq A] (newItem : YjsItem A) (arr : Array (YjsItem A))
   (horigin : ArrSet arr.toList newItem.origin) (hrorigin : ArrSet arr.toList newItem.rightOrigin)
   (horigin_consistent : YjsLt' (A := A) newItem.origin newItem.rightOrigin)
   (hreachable_consistent :
@@ -992,24 +1073,22 @@ theorem isDone_true_newItem_lt_item {A : Type} [inst : DecidableEq A] (newItem :
     apply harrinv.closed.closedLeft o r id c
     rw [<-heq]
     simp [ArrSet]
-  -- cases Nat.lt_or_ge (i + 1) ((rightIdx - leftIdx).toNat - 1) with
+  -- next is either ForInStep.done (a `break` happened) or ForInStep.yield with offset = none
+  -- (the loop reached rightIdx without breaking).
   cases next with
   | done next  =>
-    -- rw [List.getElem?_range' (by omega)] at hdone
-    -- simp at hdone
-    -- cases next with
-    -- | yield next =>
-    --   cases hdone
-    -- | done next =>
+    -- ► break path: only breakLeftOrigin or breakSameRight reached this point.
     simp [isBreak] at hitem
     have hor : oLeftIdx < leftIdx ∨ (oLeftIdx = leftIdx ∧ oRightIdx = rightIdx ∧ !(newItem.id > other.id)) := by
       split at hbody
-      . left; assumption
+      . -- breakLeftOrigin
+        left; assumption
       . split at hbody
         . split at hbody
           . cases hbody
           . split at hbody
-            . right; constructor; assumption
+            . -- breakSameRight
+              right; constructor; assumption
               constructor; assumption
               simp
               simp only [LT.lt] at |-
@@ -1043,6 +1122,8 @@ theorem isDone_true_newItem_lt_item {A : Type} [inst : DecidableEq A] (newItem :
       subst heq; omega
     cases hor with
     | inl hlt =>
+      -- ► Case breakLeftOrigin: oLeftIdx < leftIdx.
+      -- newItem < other: by totality/no_cross_origin contradicts oLeftIdx < leftIdx if other ≤ newItem.
       cases YjsLeq'_or_YjsLt' (x := other) (y := newItem) harrsetinv hclosed (by assumption) (by simp [ArrSet]) with
       | inr hlt =>
         apply hlt
@@ -1075,6 +1156,8 @@ theorem isDone_true_newItem_lt_item {A : Type} [inst : DecidableEq A] (newItem :
               simp; omega
           omega
     | inr hcond =>
+      -- ► Case breakSameRight: oLeftIdx = leftIdx ∧ oRightIdx = rightIdx ∧ ¬(newItem.id > other.id).
+      -- newItem < other via ConflictLt.ltOriginSame (same origin, same right-origin, newItem.id < other.id).
       obtain ⟨ h_oLeftIdx_eq_leftIdx, h_oRightIdx_eq_rightIdx, h_other_id_lt_newItem_id ⟩ := hcond
       have h_id_lt_id' : newItem.id < other.id := by
         simp at h_other_id_lt_newItem_id
@@ -1110,6 +1193,9 @@ theorem isDone_true_newItem_lt_item {A : Type} [inst : DecidableEq A] (newItem :
         . apply YjsLeq'.leqSame
       . assumption
   | yield h =>
+    -- ► yield path: done is true only because offset reached `none`
+    -- (the loop exhausted the range without breaking).
+    -- The boundary item is `newItem.rightOrigin` (i.e., arr[rightIdx] or YjsPtr.last).
     simp [isBreak] at hitem
     rw [Int.max_eq_left  (by omega)] at hitem
     simp at hdone
@@ -1164,6 +1250,20 @@ theorem isDone_true_newItem_lt_item {A : Type} [inst : DecidableEq A] (newItem :
     apply YjsLt'.ltRightOrigin
     apply YjsLeq'.leqSame
 
+/-- One iteration of `findIntegratedIndex`'s loop preserves `loopInv`.
+
+The proof refines `loopInv` (a 7-conjunct):
+1. **Bookkeeping** (3 conjuncts): offset bound, dest ≤ current, and
+   "¬scanning ∧ ¬done ⇒ dest = current".
+2. **Paper-aligned invariant** (4 conjuncts):
+   - `prefixLt` — preserved by `loopInv_prefixLt_preserve`.
+   - `scannedRegion` — preserved by `loopInv_scannedRegion_preserve`.
+   - `scanningOrigin` — preserved by `loopInv_scanningOrigin_preserve`.
+   - `doneLt` — preserved by `loopInv_doneLt_preserve`.
+
+Each preservation sub-lemma case-analyses the algorithm body's six branches
+(breakLeftOrigin, advanceSameOrigin, breakSameRight, pendingSameOrigin,
+advanceOtherOrigin, pendingOtherOrigin); see each sub-lemma's docstring. -/
 theorem loopInv_preserve1
   (newItem : YjsItem A)
   (arr : Array (YjsItem A))
@@ -1377,8 +1477,8 @@ theorem loopInv_preserve1
           cases hnexteq
           contradiction
   constructor
-  . -- extract_goal using dest_lt_YjsLt'_preserve
-    apply dest_lt_YjsLt'_preserve
+  . -- prefixLt: every j < nDest is still confirmed less than newItem
+    apply loopInv_prefixLt_preserve
       newItem arr horigin hrorigin horigin_consistent
       hreachable_consistent hsameid_consistent harrinv hclosed harrsetinv leftIdx heqleft rightIdx heqright
       hleftIdxrightIdx next i hlt other hother oLeftIdx hoLeftIdx oRightIdx hoRightIdx dest scanning
@@ -1386,22 +1486,22 @@ theorem loopInv_preserve1
       h_lt_item h_tbd h_done hnext_dest hnext_scanning nDest_eq hlt_current heq h_in_other h_in_other_origin h_other_origin_lt
       nDest_lt_size
   constructor
-  . -- extract_goal using nDest_geq_i_lt_current_arr_i_origin_eq_newItem_origin_or_arr_nDest_lt_arr_i_origin
-    apply nDest_geq_i_lt_current_arr_i_origin_eq_newItem_origin_or_arr_nDest_lt_arr_i_origin
+  . -- scannedRegion: pending region [nDest, newCurrent) all satisfies clause (a) or (b)
+    apply loopInv_scannedRegion_preserve
       newItem arr hsameid_consistent harrinv
       leftIdx heqleft rightIdx hleftIdxrightIdx next i hlt other hother oLeftIdx hoLeftIdx
       oRightIdx hoRightIdx dest scanning h_cand h_leftIdx h_rightIdx nDest nScanning hnexteq hrightIdx hlt hinv
       hbody hidx hdest_current h_not_scanning h_lt_item h_tbd h_done hnext_dest hnext_scanning nDest_eq
       hlt_current heq h_in_other h_in_other_origin h_other_origin_lt nDest_lt_size
   constructor
-  . -- extract_goal using scanning_dest_origin_eq_newItem_origin_preserve
-    apply scanning_dest_origin_eq_newItem_origin_preserve
+  . -- scanningOrigin: nScanning ⇒ arr[nDest].origin = newItem.origin
+    apply loopInv_scanningOrigin_preserve
       newItem arr leftIdx heqleft rightIdx next i other oLeftIdx hoLeftIdx oRightIdx dest scanning
       h_cand h_leftIdx nDest nScanning hnexteq hinv hbody hdest_current h_not_scanning
       h_lt_item h_tbd h_done hnext_dest hnext_scanning nDest_eq hlt_current heq nDest_lt_size
   . intros hdone item hitem
-    -- extract_goal using isDone_true_newItem_lt_item
-    apply isDone_true_newItem_lt_item
+    -- doneLt: when next state is done, newItem < boundary item
+    apply loopInv_doneLt_preserve
       newItem arr horigin hrorigin horigin_consistent hreachable_consistent hsameid_consistent harrinv
       hclosed harrsetinv leftIdx heqleft rightIdx heqright hleftIdxrightIdx next i hlt other hother oLeftIdx hoLeftIdx
       oRightIdx hoRightIdx dest scanning h_cand h_leftIdx h_rightIdx nDest nScanning hnexteq hrightIdx hlt hinv


### PR DESCRIPTION
## Summary
- Introduce `IntegrationInvariant` (paper-aligned 4-clause structure) and a clean `pending_propagation` lemma; replace the duplicate `loopInv_YjsLt'` propagation lemma.
- Rename the four preservation sub-lemmas to paper-aligned names and add docstrings + per-branch ► Case markers so each algorithm branch's proof obligation is visible.

## Why
The Lean proof of `YjsArrInvariant_integrate` previously buried the algorithm's case structure inside three layers of helpers (`loopInv` 7-conjunct, four parallel preservation sub-lemmas with cryptic names like `dest_lt_YjsLt'_preserve` and `nDest_geq_i_lt_current_arr_i_origin_eq_newItem_origin_or_arr_nDest_lt_arr_i_origin`, then `loopInv_preserve1` dispatching to all four). The paper's §"Insert Algorithm and Commutativity" describes the same proof in terms of six labeled cases (`breakLeftOrigin` / `advanceSameOrigin` / `breakSameRight` / `pendingSameOrigin` / `advanceOtherOrigin` / `pendingOtherOrigin`) and four invariant clauses. This PR realigns the Lean proof's surface so the case structure is readable.

## What changed

### Phase 1 (\`ed909d0\`): IntegrationInvariant + pending_propagation
- Add \`structure IntegrationInvariant\` with paper-aligned fields \`prefixLt\` / \`scannedRegion\` / \`scanningOrigin\` / \`doneLt\`.
- Add \`theorem pending_propagation\` taking the structure's clauses directly (no \`loopInv\` middleman).
- Add \`loopInv_to_IntegrationInvariant\` bridge so the existing 7-conjunct \`loopInv\` keeps working.
- Drop the duplicated \`loopInv_YjsLt'\`. Update the post-loop block of \`YjsArrInvariant_integrate\` to use \`pending_propagation\` via the bridge.

### Phase 2 (\`f20c4d3\`): paper-aligned names + case markers
- Rename:
  - \`dest_lt_YjsLt'_preserve\` → \`loopInv_prefixLt_preserve\`
  - \`nDest_geq_..._preserve\` → \`loopInv_scannedRegion_preserve\`
  - \`scanning_dest_origin_eq_..._preserve\` → \`loopInv_scanningOrigin_preserve\`
  - \`isDone_true_newItem_lt_item\` → \`loopInv_doneLt_preserve\`
- Each sub-lemma carries a docstring summarising what it preserves and how the six cases contribute. Inline \`► Case X\` markers replace the previous unstructured branch comments.
- \`loopInv_preserve1\` carries a top-level docstring explaining the 7-conjunct structure (3 bookkeeping + 4 paper clauses).

## What's deferred
Full mvcgen migration of \`findIntegratedIndex\`'s loop reasoning (Phase 3) was scoped out: it would require translating the existing \`loopInv\` invariant into mvcgen's \`(xs, st)\` form and discharging ~20+ VCs while reusing \`loopInv_preserve1\`. The Phase 1+2 work already delivers the readability goal; mvcgen migration becomes a separate, focused effort.

## Test plan
- [x] \`lake build\` passes (923 jobs)
- [x] axiom check on \`Spec.lean\`: only standard axioms (propext / Classical.choice / Quot.sound)
- [x] \`sorry_analyzer.py\`: 0 sorries
- [x] No public API changes (only internal preservation helper renames)

🤖 Generated with [Claude Code](https://claude.com/claude-code)